### PR TITLE
Updated for Spree 3.2.x and Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,11 @@ gem 'spree', github: 'spree/spree', branch: '3-2-stable'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 
-gem 'state_machines-activerecord'
 
 group :test do
   gem 'shoulda-matchers', '~> 3.1.1'
   gem 'rspec-activemodel-mocks', '~> 1.0.3'
-  gem 'rails-controller-testing'
+  gem 'rails-controller-testing', '~> 1.0.1'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,15 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '3-1-stable'
+gem 'spree', github: 'spree/spree', branch: '3-2-stable'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 
-gem 'state_machines-activerecord', '~> 0.3.0'
+gem 'state_machines-activerecord'
 
 group :test do
-  gem 'minitest'
-  gem 'rspec-rails', '~> 3.4.0'
   gem 'shoulda-matchers', '~> 3.1.1'
   gem 'rspec-activemodel-mocks', '~> 1.0.3'
+  gem 'rails-controller-testing'
 end
 
 gemspec

--- a/app/controllers/spree/admin/general_settings_controller_decorator.rb
+++ b/app/controllers/spree/admin/general_settings_controller_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Admin::GeneralSettingsController.class_eval do
-  before_filter :update_quotes_settings, only: :update
+  before_action :update_quotes_settings, only: :update
 
   private
 

--- a/app/controllers/spree/admin/quotes_controller.rb
+++ b/app/controllers/spree/admin/quotes_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class QuotesController < ResourceController
-      before_filter :load_quote, only: [:publish, :unpublish]
+      before_action :load_quote, only: [:publish, :unpublish]
 
       def index
         @quotes = ::Spree::Quote.order(::Spree::Quote.arel_table[:rank].eq(nil), :rank, created_at: :desc)

--- a/app/controllers/spree/home_controller_decorator.rb
+++ b/app/controllers/spree/home_controller_decorator.rb
@@ -1,5 +1,5 @@
 Spree::HomeController.class_eval do
-  before_filter :set_top_quotes, :set_new_quote, only: :index
+  before_action :set_top_quotes, :set_new_quote, only: :index
 
   private
 

--- a/app/models/spree/quote.rb
+++ b/app/models/spree/quote.rb
@@ -72,7 +72,7 @@ module Spree
       def restrict_if_published
         if published?
           errors.add(:Base, Spree.t(:destroy_published_quote))
-          false
+          throw(:abort)
         end
       end
 

--- a/spec/controllers/spree/admin/general_settings_controller_decorator_spec.rb
+++ b/spec/controllers/spree/admin/general_settings_controller_decorator_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Admin::GeneralSettingsController, type: :controller do
   end
 
   def do_update
-    post :update, disable_quote: true, quotes_count: 10, store: { url: 'www.spree.com' }
+    post :update, params: { disable_quote: true, quotes_count: 10, store: { url: 'www.spree.com' } }
   end
 
   describe '#update' do

--- a/spec/controllers/spree/admin/quotes_controller_spec.rb
+++ b/spec/controllers/spree/admin/quotes_controller_spec.rb
@@ -9,6 +9,7 @@ describe Spree::Admin::QuotesController, type: :controller do
     allow(controller).to receive_messages spree_current_user: user
     user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
     allow(request).to receive_messages referrer: admin_quotes_path
+    request.env["HTTP_REFERER"] = admin_quotes_path
   end
 
   def do_index
@@ -16,11 +17,11 @@ describe Spree::Admin::QuotesController, type: :controller do
   end
 
   def do_publish(quote)
-    get :publish, id: quote.id
+    get :publish, params: { id: quote.id }
   end
 
   def do_unpublish(quote)
-    get :unpublish, id: quote.id
+    get :unpublish, params: { id: quote.id }
   end
 
   describe '#index' do

--- a/spec/controllers/spree/quotes_controller_spec.rb
+++ b/spec/controllers/spree/quotes_controller_spec.rb
@@ -9,7 +9,7 @@ describe Spree::QuotesController, type: :controller do
   end
 
   def do_create
-    xhr :post, :create, quote: { description: 'abc', author_name: 'xyz', user_id: user.id }
+    post :create, params: { quote: { description: 'abc', author_name: 'xyz', user_id: user.id } }, xhr: true
   end
 
   describe '#create' do

--- a/spree_quotes_management.gemspec
+++ b/spree_quotes_management.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_quotes_management'
-  s.version     = '3.1.0'
+  s.version     = '3.2.0'
   s.summary     = 'Quotes Management'
   s.description = 'At user end
                       -user can quote about the site.
@@ -23,16 +23,16 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.1.0'
-  s.add_dependency 'state_machines-activerecord', '~> 0.3.0'
+  s.add_dependency 'spree_core', '~> 3.2.0.rc2'
+  s.add_dependency 'state_machines-activerecord'
 
-  s.add_development_dependency 'capybara', '~> 2.4'
+  s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl', '~> 4.5'
-  s.add_development_dependency 'ffaker', '~> 2.2.0'
-  s.add_development_dependency 'rspec-rails',  '~> 3.1'
-  s.add_development_dependency 'sass-rails', '~> 5.0.0.beta1'
+  s.add_development_dependency 'ffaker'
+  s.add_development_dependency 'rspec-rails',  '~> 3.4'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'

--- a/spree_quotes_management.gemspec
+++ b/spree_quotes_management.gemspec
@@ -24,16 +24,16 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 3.2.0.rc2'
-  s.add_dependency 'state_machines-activerecord'
+  s.add_dependency 'state_machines-activerecord', '~> 0.4.0'
 
   s.add_development_dependency 'capybara', '~> 2.6'
-  s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency 'database_cleaner'
+  s.add_development_dependency 'coffee-rails', '~> 4.2.1'
+  s.add_development_dependency 'database_cleaner', '~> 1.5.3'
   s.add_development_dependency 'factory_girl', '~> 4.5'
-  s.add_development_dependency 'ffaker'
+  s.add_development_dependency 'ffaker', '~> 2.2.0'
   s.add_development_dependency 'rspec-rails',  '~> 3.4'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
-  s.add_development_dependency 'selenium-webdriver'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'selenium-webdriver', '~> 3.0.8'
+  s.add_development_dependency 'simplecov', '~> 0.13.0'
+  s.add_development_dependency 'sqlite3', '~> 1.3.13'
 end


### PR DESCRIPTION
Added gem 'rails-controller-testing' needed to use assigns and render_template in tests
Fixed deprecation warning before_filter -> before_action
Fixed deprecation warning - use keyword syntax for get, put etc in controller tests
Fixed failing test by setting referrer in request env, rspec expectation didn't worked
Added throw(:abort) as per Rails 5 to halt callback chain instead of returning false